### PR TITLE
Remove throws, resolves, rejects, and fromNow callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Mock
 
-[![release](https://img.shields.io/badge/release-0.10.1-success)](https://github.com/udibo/mock/releases/tag/0.10.1)
-[![deno doc](https://doc.deno.land/badge.svg)](https://doc.deno.land/https/deno.land/x/mock@0.10.1/mod.ts)
+[![release](https://img.shields.io/badge/release-0.11.0-success)](https://github.com/udibo/mock/releases/tag/0.11.0)
+[![deno doc](https://doc.deno.land/badge.svg)](https://doc.deno.land/https/deno.land/x/mock@0.11.0/mod.ts)
 [![CI](https://github.com/udibo/mock/workflows/CI/badge.svg)](https://github.com/udibo/mock/actions?query=workflow%3ACI)
 [![codecov](https://codecov.io/gh/udibo/mock/branch/master/graph/badge.svg?token=TXORMSEHM7)](https://codecov.io/gh/udibo/mock)
 [![license](https://img.shields.io/github/license/udibo/mock)](https://github.com/udibo/mock/blob/master/LICENSE)
@@ -30,9 +30,9 @@ imported directly from GitHub using raw content URLs.
 
 ```ts
 // Import from Deno's third party module registry
-import { spy, Spy } from "https://deno.land/x/mock@0.10.1/mod.ts";
+import { spy, Spy } from "https://deno.land/x/mock@0.11.0/mod.ts";
 // Import from GitHub
-import { spy, Spy } "https://raw.githubusercontent.com/udibo/mock/0.10.1/mod.ts";
+import { spy, Spy } "https://raw.githubusercontent.com/udibo/mock/0.11.0/mod.ts";
 ```
 
 If you do not need all of the sub-modules, you can choose to just import the
@@ -40,12 +40,12 @@ sub-modules you need.
 
 ```ts
 // Import from Deno's third party module registry
-import { Spy, spy } from "https://deno.land/x/mock@0.10.1/spy.ts";
+import { Spy, spy } from "https://deno.land/x/mock@0.11.0/spy.ts";
 // Import from GitHub
 import {
   Spy,
   spy,
-} from "https://raw.githubusercontent.com/udibo/mock/0.10.1/spy.ts";
+} from "https://raw.githubusercontent.com/udibo/mock/0.11.0/spy.ts";
 ```
 
 #### Sub-modules
@@ -69,7 +69,7 @@ If a Node.js package has the type "module" specified in its package.json file,
 the JavaScript bundle can be imported as a `.js` file.
 
 ```js
-import { Spy, spy } from "./mock_0.10.1.js";
+import { Spy, spy } from "./mock_0.11.0.js";
 ```
 
 The default type for Node.js packages is "commonjs". To import the bundle into a
@@ -77,7 +77,7 @@ commonjs package, the file extension of the JavaScript bundle must be changed
 from `.js` to `.mjs`.
 
 ```js
-import { Spy, spy } from "./mock_0.10.1.mjs";
+import { Spy, spy } from "./mock_0.11.0.mjs";
 ```
 
 See [Node.js Documentation](https://nodejs.org/api/esm.html) for more
@@ -96,7 +96,7 @@ modules must have the type attribute set to "module".
 
 ```js
 // main.js
-import { Spy, spy } from "./mock_0.10.1.js";
+import { Spy, spy } from "./mock_0.11.0.js";
 ```
 
 You can also embed a module script directly into an HTML file by placing the
@@ -104,7 +104,7 @@ JavaScript code within the body of the script tag.
 
 ```html
 <script type="module">
-  import { spy, Spy } from "./mock_0.10.1.js";
+  import { spy, Spy } from "./mock_0.11.0.js";
 </script>
 ```
 
@@ -120,7 +120,7 @@ a try block then restore the function in a finally block to ensure the original
 instance method is restored before continuing to other tests. The same applies
 when using fake time.
 
-See [deno docs](https://doc.deno.land/https/deno.land/x/mock@0.10.1/mod.ts) for
+See [deno docs](https://doc.deno.land/https/deno.land/x/mock@0.11.0/mod.ts) for
 more information.
 
 ### Spy
@@ -135,9 +135,9 @@ anything, you can create an empty spy. An empty spy will just return undefined
 for any calls made to it.
 
 ```ts
-import { assertEquals } from "https://deno.land/std@0.107.0/testing/asserts.ts";
-import { assertSpyCall } from "https://deno.land/x/mock@0.10.1/asserts.ts";
-import { Spy, spy } from "https://deno.land/x/mock@0.10.1/spy.ts";
+import { assertEquals } from "https://deno.land/std@0.114.0/testing/asserts.ts";
+import { assertSpyCall } from "https://deno.land/x/mock@0.11.0/asserts.ts";
+import { Spy, spy } from "https://deno.land/x/mock@0.11.0/spy.ts";
 
 function add(
   a: number,
@@ -145,7 +145,7 @@ function add(
   callback: (error: Error | void, value?: number) => void,
 ): void {
   const value: number = a + b;
-  if (typeof value === "number" && value !== NaN) callback(undefined, value);
+  if (typeof value === "number" && !isNaN(value)) callback(undefined, value);
   else callback(new Error("invalid input"));
 }
 
@@ -163,8 +163,8 @@ If you have a function that takes a callback that needs to still behave
 normally, you can wrap it with a spy.
 
 ```ts
-import { assertEquals } from "https://deno.land/std@0.107.0/testing/asserts.ts";
-import { Spy, spy } from "https://deno.land/x/mock@0.10.1/spy.ts";
+import { assertEquals } from "https://deno.land/std@0.114.0/testing/asserts.ts";
+import { Spy, spy } from "https://deno.land/x/mock@0.11.0/spy.ts";
 
 function filter<T>(values: T[], callback: (value: T) => boolean): any[] {
   return values.filter(callback);
@@ -195,8 +195,8 @@ method. If it is not restored and you attempt to wrap it again, it will throw a
 spy error saying "already spying on function".
 
 ```ts
-import { assertEquals } from "https://deno.land/std@0.107.0/testing/asserts.ts";
-import { Spy, spy } from "https://deno.land/x/mock@0.10.1/spy.ts";
+import { assertEquals } from "https://deno.land/std@0.114.0/testing/asserts.ts";
+import { Spy, spy } from "https://deno.land/x/mock@0.11.0/spy.ts";
 
 class Database {
   private queries: any;
@@ -286,8 +286,8 @@ return values after initialization by replacing or adding to the `stub.returns`
 queue. When the returns queue is empty, it will return undefined.
 
 ```ts
-import { assertEquals } from "https://deno.land/std@0.107.0/testing/asserts.ts";
-import { Stub, stub } from "https://deno.land/x/mock@0.10.1/stub.ts";
+import { assertEquals } from "https://deno.land/std@0.114.0/testing/asserts.ts";
+import { Stub, stub } from "https://deno.land/x/mock@0.11.0/stub.ts";
 
 class Cat {
   action(name: string): any {
@@ -323,8 +323,8 @@ them returned. You can add more return values after initialization by replacing
 or adding to the `stub.returns` queue.
 
 ```ts
-import { assertEquals } from "https://deno.land/std@0.107.0/testing/asserts.ts";
-import { Stub, stub } from "https://deno.land/x/mock@0.10.1/stub.ts";
+import { assertEquals } from "https://deno.land/std@0.114.0/testing/asserts.ts";
+import { Stub, stub } from "https://deno.land/x/mock@0.11.0/stub.ts";
 
 class Database {
   query(query: string, params: any[]): any[][] {
@@ -399,8 +399,8 @@ initialization by replacing or adding to the `stub.returns` queue. When the
 returns queue is empty, it will call the replacement function.
 
 ```ts
-import { assertEquals } from "https://deno.land/std@0.107.0/testing/asserts.ts";
-import { Stub, stub } from "https://deno.land/x/mock@0.10.1/stub.ts";
+import { assertEquals } from "https://deno.land/std@0.114.0/testing/asserts.ts";
+import { Stub, stub } from "https://deno.land/x/mock@0.11.0/stub.ts";
 
 class Database {
   query(query: string, params: any[]): any[][] {
@@ -475,9 +475,9 @@ Overrides the real Date object and timer functions with fake ones that can be
 controlled through the fake time instance.
 
 ```ts
-import { assertEquals } from "https://deno.land/std@0.107.0/testing/asserts.ts";
-import { Spy, spy } from "https://deno.land/x/mock@0.10.1/spy.ts";
-import { FakeTime } from "https://deno.land/x/mock@0.10.1/time.ts";
+import { assertEquals } from "https://deno.land/std@0.114.0/testing/asserts.ts";
+import { Spy, spy } from "https://deno.land/x/mock@0.11.0/spy.ts";
+import { FakeTime } from "https://deno.land/x/mock@0.11.0/time.ts";
 
 function secondInterval(cb: () => void): void {
   setInterval(cb, 1000);

--- a/asserts.ts
+++ b/asserts.ts
@@ -3,9 +3,9 @@
 import {
   assertEquals,
   AssertionError,
+  assertIsError,
+  assertRejects,
   assertStrictEquals,
-  assertThrows,
-  assertThrowsAsync,
 } from "./deps.ts";
 import { Spy, SpyCall, Stub, stub } from "./stub.ts";
 
@@ -247,12 +247,10 @@ export function assertSpyCall(
           "spy call did not throw an error, a value was returned.",
         );
       }
-      assertThrows(
-        () => {
-          throw call.error;
-        },
+      assertIsError(
+        call.error,
         expected.error?.Class ?? Error,
-        expected.error?.msg ?? "",
+        expected.error?.msg,
       );
     }
   }
@@ -330,7 +328,7 @@ export async function assertSpyCallAsync(
     }
 
     if ("error" in expected) {
-      await assertThrowsAsync(
+      await assertRejects(
         () => call.returned,
         expected.error?.Class ?? Error,
         expected.error?.msg ?? "",

--- a/asserts_test.ts
+++ b/asserts_test.ts
@@ -1,4 +1,4 @@
-import { AssertionError, assertThrows, assertThrowsAsync } from "./deps.ts";
+import { AssertionError, assertRejects, assertThrows } from "./deps.ts";
 import {
   assertPassthrough,
   assertSpyCall,
@@ -610,7 +610,7 @@ Deno.test("assertSpyCall error", () => {
 Deno.test("assertSpyCallAsync function", async () => {
   const spyFunc: Spy<void> = spy(() => Promise.resolve(5));
 
-  await assertThrowsAsync(
+  await assertRejects(
     () => assertSpyCallAsync(spyFunc, 0),
     AssertionError,
     "spy not called as much as expected",
@@ -638,7 +638,7 @@ Deno.test("assertSpyCallAsync function", async () => {
     returned: Promise.resolve(5),
   });
 
-  await assertThrowsAsync(
+  await assertRejects(
     () =>
       assertSpyCallAsync(spyFunc, 0, {
         args: [1],
@@ -648,7 +648,7 @@ Deno.test("assertSpyCallAsync function", async () => {
     AssertionError,
     "spy not called with expected args",
   );
-  await assertThrowsAsync(
+  await assertRejects(
     () =>
       assertSpyCallAsync(spyFunc, 0, {
         args: [1],
@@ -656,7 +656,7 @@ Deno.test("assertSpyCallAsync function", async () => {
     AssertionError,
     "spy not called with expected args",
   );
-  await assertThrowsAsync(
+  await assertRejects(
     () =>
       assertSpyCallAsync(spyFunc, 0, {
         self: {},
@@ -664,7 +664,7 @@ Deno.test("assertSpyCallAsync function", async () => {
     AssertionError,
     "spy not called as method on expected self",
   );
-  await assertThrowsAsync(
+  await assertRejects(
     () =>
       assertSpyCallAsync(spyFunc, 0, {
         returned: 2,
@@ -672,7 +672,7 @@ Deno.test("assertSpyCallAsync function", async () => {
     AssertionError,
     "spy call did not resolve to expected value",
   );
-  await assertThrowsAsync(
+  await assertRejects(
     () =>
       assertSpyCallAsync(spyFunc, 0, {
         returned: Promise.resolve(2),
@@ -680,7 +680,7 @@ Deno.test("assertSpyCallAsync function", async () => {
     AssertionError,
     "spy call did not resolve to expected value",
   );
-  await assertThrowsAsync(
+  await assertRejects(
     () => assertSpyCallAsync(spyFunc, 1),
     AssertionError,
     "spy not called as much as expected",
@@ -695,7 +695,7 @@ Deno.test("assertSpyCallAsync method", async () => {
     (x?: number) => Promise.resolve(x),
   );
 
-  await assertThrowsAsync(
+  await assertRejects(
     () => assertSpyCallAsync(spyMethod, 0),
     AssertionError,
     "spy not called as much as expected",
@@ -726,7 +726,7 @@ Deno.test("assertSpyCallAsync method", async () => {
     returned: Promise.resolve(3),
   });
 
-  await assertThrowsAsync(
+  await assertRejects(
     () =>
       assertSpyCallAsync(spyMethod, 0, {
         args: [7, 4],
@@ -736,7 +736,7 @@ Deno.test("assertSpyCallAsync method", async () => {
     AssertionError,
     "spy not called with expected args",
   );
-  await assertThrowsAsync(
+  await assertRejects(
     () =>
       assertSpyCallAsync(spyMethod, 0, {
         args: [7, 3],
@@ -744,7 +744,7 @@ Deno.test("assertSpyCallAsync method", async () => {
     AssertionError,
     "spy not called with expected args",
   );
-  await assertThrowsAsync(
+  await assertRejects(
     () =>
       assertSpyCallAsync(spyMethod, 0, {
         self: undefined,
@@ -752,7 +752,7 @@ Deno.test("assertSpyCallAsync method", async () => {
     AssertionError,
     "spy not expected to be called as method on object",
   );
-  await assertThrowsAsync(
+  await assertRejects(
     () =>
       assertSpyCallAsync(spyMethod, 0, {
         returned: 7,
@@ -760,7 +760,7 @@ Deno.test("assertSpyCallAsync method", async () => {
     AssertionError,
     "spy call did not resolve to expected value",
   );
-  await assertThrowsAsync(
+  await assertRejects(
     () =>
       assertSpyCallAsync(spyMethod, 0, {
         returned: Promise.resolve(7),
@@ -768,7 +768,7 @@ Deno.test("assertSpyCallAsync method", async () => {
     AssertionError,
     "spy call did not resolve to expected value",
   );
-  await assertThrowsAsync(
+  await assertRejects(
     () => assertSpyCallAsync(spyMethod, 1),
     AssertionError,
     "spy not called as much as expected",
@@ -799,7 +799,7 @@ Deno.test("assertSpyCallAsync method", async () => {
     returned: Promise.resolve(9),
   });
 
-  await assertThrowsAsync(
+  await assertRejects(
     () =>
       assertSpyCallAsync(spyMethod, 1, {
         args: [7, 4],
@@ -809,7 +809,7 @@ Deno.test("assertSpyCallAsync method", async () => {
     AssertionError,
     "spy not called with expected args",
   );
-  await assertThrowsAsync(
+  await assertRejects(
     () =>
       assertSpyCallAsync(spyMethod, 1, {
         args: [7, 3],
@@ -817,7 +817,7 @@ Deno.test("assertSpyCallAsync method", async () => {
     AssertionError,
     "spy not called with expected args",
   );
-  await assertThrowsAsync(
+  await assertRejects(
     () =>
       assertSpyCallAsync(spyMethod, 1, {
         self: point,
@@ -825,7 +825,7 @@ Deno.test("assertSpyCallAsync method", async () => {
     AssertionError,
     "spy not called as method on expected self",
   );
-  await assertThrowsAsync(
+  await assertRejects(
     () =>
       assertSpyCallAsync(spyMethod, 1, {
         returned: 7,
@@ -833,7 +833,7 @@ Deno.test("assertSpyCallAsync method", async () => {
     AssertionError,
     "spy call did not resolve to expected value",
   );
-  await assertThrowsAsync(
+  await assertRejects(
     () =>
       assertSpyCallAsync(spyMethod, 1, {
         returned: Promise.resolve(7),
@@ -841,7 +841,7 @@ Deno.test("assertSpyCallAsync method", async () => {
     AssertionError,
     "spy call did not resolve to expected value",
   );
-  await assertThrowsAsync(
+  await assertRejects(
     () => assertSpyCallAsync(spyMethod, 2),
     AssertionError,
     "spy not called as much as expected",
@@ -852,7 +852,7 @@ Deno.test("assertSpyCallAync on sync value", async () => {
   const spyFunc: Spy<void> = spy(() => 4);
 
   await spyFunc();
-  await assertThrowsAsync(
+  await assertRejects(
     () => assertSpyCallAsync(spyFunc, 0),
     AssertionError,
     "spy call did not return a promise, a value was returned.",
@@ -864,8 +864,8 @@ Deno.test("assertSpyCallAync on sync error", async () => {
     throw new ExampleError("failed");
   });
 
-  await assertThrowsAsync(() => spyFunc(), ExampleError, "fail");
-  await assertThrowsAsync(
+  await assertRejects(() => spyFunc(), ExampleError, "fail");
+  await assertRejects(
     () => assertSpyCallAsync(spyFunc, 0),
     AssertionError,
     "spy call did not return a promise, an error was thrown.",
@@ -877,7 +877,7 @@ Deno.test("assertSpyCallAync error", async () => {
     Promise.reject(new ExampleError("failed"))
   );
 
-  await assertThrowsAsync(() => spyFunc(), ExampleError, "fail");
+  await assertRejects(() => spyFunc(), ExampleError, "fail");
   await assertSpyCallAsync(spyFunc, 0);
   await assertSpyCallAsync(spyFunc, 0, {
     args: [],
@@ -906,7 +906,7 @@ Deno.test("assertSpyCallAync error", async () => {
     },
   });
 
-  await assertThrowsAsync(
+  await assertRejects(
     () =>
       assertSpyCallAsync(spyFunc, 0, {
         args: [1],
@@ -919,7 +919,7 @@ Deno.test("assertSpyCallAync error", async () => {
     AssertionError,
     "spy not called with expected args",
   );
-  await assertThrowsAsync(
+  await assertRejects(
     () =>
       assertSpyCallAsync(spyFunc, 0, {
         args: [1],
@@ -927,7 +927,7 @@ Deno.test("assertSpyCallAync error", async () => {
     AssertionError,
     "spy not called with expected args",
   );
-  await assertThrowsAsync(
+  await assertRejects(
     () =>
       assertSpyCallAsync(spyFunc, 0, {
         self: {},
@@ -935,7 +935,7 @@ Deno.test("assertSpyCallAync error", async () => {
     AssertionError,
     "spy not called as method on expected self",
   );
-  await assertThrowsAsync(
+  await assertRejects(
     () =>
       assertSpyCallAsync(spyFunc, 0, {
         error: {
@@ -946,7 +946,7 @@ Deno.test("assertSpyCallAync error", async () => {
     AssertionError,
     'Expected error to be instance of "OtherError"',
   );
-  await assertThrowsAsync(
+  await assertRejects(
     () =>
       assertSpyCallAsync(spyFunc, 0, {
         error: {
@@ -957,7 +957,7 @@ Deno.test("assertSpyCallAync error", async () => {
     AssertionError,
     'Expected error to be instance of "OtherError"',
   );
-  await assertThrowsAsync(
+  await assertRejects(
     () =>
       assertSpyCallAsync(spyFunc, 0, {
         error: {
@@ -968,7 +968,7 @@ Deno.test("assertSpyCallAync error", async () => {
     AssertionError,
     'Expected error message to include "x", but got "failed".',
   );
-  await assertThrowsAsync(
+  await assertRejects(
     () =>
       assertSpyCallAsync(spyFunc, 0, {
         error: {
@@ -979,7 +979,7 @@ Deno.test("assertSpyCallAync error", async () => {
     AssertionError,
     'Expected error message to include "x", but got "failed".',
   );
-  await assertThrowsAsync(
+  await assertRejects(
     () =>
       assertSpyCallAsync(spyFunc, 0, {
         error: {
@@ -989,7 +989,7 @@ Deno.test("assertSpyCallAync error", async () => {
     AssertionError,
     'Expected error message to include "x", but got "failed".',
   );
-  await assertThrowsAsync(
+  await assertRejects(
     () =>
       assertSpyCallAsync(spyFunc, 0, {
         returned: 7,
@@ -997,7 +997,7 @@ Deno.test("assertSpyCallAync error", async () => {
     AssertionError,
     "spy call returned promise was rejected",
   );
-  await assertThrowsAsync(
+  await assertRejects(
     () =>
       assertSpyCallAsync(spyFunc, 0, {
         returned: 7,
@@ -1006,7 +1006,7 @@ Deno.test("assertSpyCallAync error", async () => {
     TypeError,
     "do not expect error and return, only one should be expected",
   );
-  await assertThrowsAsync(
+  await assertRejects(
     () => assertSpyCallAsync(spyFunc, 1),
     AssertionError,
     "spy not called as much as expected",

--- a/callbacks.ts
+++ b/callbacks.ts
@@ -26,29 +26,3 @@ export function returnsArgs(
     return Array.prototype.slice.call(arguments, start, end);
   };
 }
-
-/** Creates a function that throws a specific error. */
-// deno-lint-ignore no-explicit-any
-export function throws(error: any): (...args: any[]) => any {
-  return function () {
-    throw error;
-  };
-}
-
-/** Creates a function that returns a promise that will resolve a specific value. */
-// deno-lint-ignore no-explicit-any
-export function resolves(value: any): (...args: any[]) => Promise<any> {
-  return () => Promise.resolve(value);
-}
-
-/** Creates a function that returns a promise that will reject a specific error. */
-// deno-lint-ignore no-explicit-any
-export function rejects(error: any): (...args: any[]) => Promise<any> {
-  return () => Promise.reject(error);
-}
-
-/** Creates a function that returns the time difference between when it is called and when it was created. */
-export function fromNow(): () => number {
-  const start: number = Date.now();
-  return () => Date.now() - start;
-}

--- a/callbacks_test.ts
+++ b/callbacks_test.ts
@@ -1,12 +1,5 @@
-import { assertEquals, assertThrows, assertThrowsAsync } from "./deps.ts";
-import {
-  rejects,
-  resolves,
-  returnsArg,
-  returnsArgs,
-  returnsThis,
-  throws,
-} from "./callbacks.ts";
+import { assertEquals } from "./deps.ts";
+import { returnsArg, returnsArgs, returnsThis } from "./callbacks.ts";
 
 Deno.test("returnsThis", () => {
   const callback = returnsThis();
@@ -44,41 +37,4 @@ Deno.test("returnsArgs", () => {
   assertEquals(callback("b", "c"), ["c"]);
   assertEquals(callback("d", "e", "f"), ["e", "f"]);
   assertEquals(callback("d", "e", "f", "g"), ["e", "f"]);
-});
-
-Deno.test("throws", () => {
-  let callback = throws(new Error("not found"));
-  assertThrows(
-    () => callback(),
-    Error,
-    "not found",
-  );
-  callback = throws(new Error("invalid"));
-  assertThrows(
-    () => callback(),
-    Error,
-    "invalid",
-  );
-});
-
-Deno.test("resolves", async () => {
-  let callback = resolves(2);
-  assertEquals(await callback(), 2);
-  callback = resolves(3);
-  assertEquals(await callback(), 3);
-});
-
-Deno.test("rejects", async () => {
-  let callback = rejects(new Error("not found"));
-  await assertThrowsAsync(
-    callback,
-    Error,
-    "not found",
-  );
-  callback = rejects(new Error("invalid"));
-  await assertThrowsAsync(
-    callback,
-    Error,
-    "invalid",
-  );
 });

--- a/deps.ts
+++ b/deps.ts
@@ -1,14 +1,15 @@
-export { delay } from "https://deno.land/std@0.107.0/async/delay.ts";
+export { delay } from "https://deno.land/std@0.114.0/async/delay.ts";
 
 export {
   assert,
   assertEquals,
   AssertionError,
+  assertIsError,
   assertNotEquals,
+  assertRejects,
   assertStrictEquals,
   assertThrows,
-  assertThrowsAsync,
-} from "https://deno.land/std@0.107.0/testing/asserts.ts";
+} from "https://deno.land/std@0.114.0/testing/asserts.ts";
 
 export { RBTree } from "https://deno.land/x/collections@0.11.2/trees/rb_tree.ts";
 export { ascend } from "https://deno.land/x/collections@0.11.2/comparators.ts";

--- a/examples/spy_default_test.ts
+++ b/examples/spy_default_test.ts
@@ -8,7 +8,7 @@ function add(
   callback: (error: Error | void, value?: number) => void,
 ): void {
   const value: number = a + b;
-  if (typeof value === "number" && value !== NaN) callback(undefined, value);
+  if (typeof value === "number" && !isNaN(value)) callback(undefined, value);
   else callback(new Error("invalid input"));
 }
 

--- a/mod.ts
+++ b/mod.ts
@@ -15,15 +15,7 @@ export {
 } from "./time.ts";
 export type { FakeDateConstructor, NativeDateConstructor } from "./time.ts";
 
-export {
-  fromNow,
-  rejects,
-  resolves,
-  returnsArg,
-  returnsArgs,
-  returnsThis,
-  throws,
-} from "./callbacks.ts";
+export { returnsArg, returnsArgs, returnsThis } from "./callbacks.ts";
 
 export {
   assertPassthrough,

--- a/time_test.ts
+++ b/time_test.ts
@@ -7,7 +7,11 @@ import {
 import { delay, FakeDate, FakeTime, NativeDate } from "./time.ts";
 import { Spy, spy, SpyCall } from "./spy.ts";
 import { assertPassthrough } from "./asserts.ts";
-import { fromNow } from "./callbacks.ts";
+
+function fromNow(): () => number {
+  const start: number = Date.now();
+  return () => Date.now() - start;
+}
 
 Deno.test("FakeDate parse and UTC behave the same", () => {
   assertEquals(


### PR DESCRIPTION
The fromNow callback's very specific to my test coverage for time.ts. Most people won't need something like that and it's easy to implement, so I've moved that to time_test.ts.

In every case where I want a stub to throw, resolve, or reject,  it has been better to just create an arrow function that throws or calls Promise.resolve/reject so that each call produces a new error object with the correct stacktrace rather than re-using the same error with an incorrect stacktrace.