### PR TITLE
Add test coverage for advanceRate and advanceFrequency options

### DIFF
--- a/time_test.ts
+++ b/time_test.ts
@@ -536,69 +536,23 @@ Deno.test("runAllAsync runs all microtasks and timers", async () => {
   }
 });
 
-Deno.test("FakeTime ticks forward when advanceRate is set", async () => {
-  let time: FakeTime = new FakeTime(null, { advanceRate: 1 });
-
-  try {
-    let start: number = Date.now();
-    await time.delay(5);
-    assertEquals(Date.now(), start);
-    await time.delay(5);
-    await time.delay(5);
-    assert(Date.now() >= start + 10);
-    assert(Date.now() < start + 30);
-    await time.delay(15);
-    await time.delay(5);
-    assert(Date.now() >= start + 30);
-    time.restore();
-
-    time = new FakeTime(null, { advanceRate: 1000 });
-    start = Date.now();
-    await time.delay(5);
-    assertEquals(Date.now(), start);
-    await time.delay(5);
-    await time.delay(5);
-    assert(Date.now() >= start + 10000);
-    assert(Date.now() < start + 30000);
-    await time.delay(15);
-    await time.delay(5);
-    assert(Date.now() >= start + 30000);
-  } finally {
-    time.restore();
-  }
-});
-
 Deno.test("FakeTime ticks forward at advanceFrequency when advanceRate is set", async () => {
-  let time: FakeTime = new FakeTime(
+  const time: FakeTime = new FakeTime(
     null,
-    { advanceRate: 1, advanceFrequency: 15 },
+    { advanceRate: 15, advanceFrequency: 100 },
   );
 
   try {
-    let start: number = Date.now();
-    await time.delay(5);
+    const start = Date.now();
+    await time.delay(50);
     assertEquals(Date.now(), start);
-    await time.delay(10);
+    await time.delay(100);
     await time.delay(5);
-    assert(Date.now() >= start + 15);
-    assert(Date.now() < start + 45);
-    await time.delay(25);
+    assert(Date.now() >= start + 1500);
+    assert(Date.now() < start + 4500);
+    await time.delay(200);
     await time.delay(5);
-    assert(Date.now() >= start + 45);
-    time.restore();
-
-    time = new FakeTime(null, { advanceRate: 1000, advanceFrequency: 15 });
-    start = Date.now();
-    await time.delay(5);
-    assertEquals(Date.now(), start);
-    await time.delay(10);
-    await time.delay(5);
-    assert(Date.now() >= start + 15000);
-    assert(Date.now() < start + 45000);
-    await time.delay(25);
-    await time.delay(5);
-    assert(Date.now() >= start + 45000);
-    start = Date.now();
+    assert(Date.now() >= start + 4500);
   } finally {
     time.restore();
   }

--- a/time_test.ts
+++ b/time_test.ts
@@ -544,15 +544,19 @@ Deno.test("FakeTime ticks forward at advanceFrequency when advanceRate is set", 
 
   try {
     const start = Date.now();
-    await time.delay(20);
-    await time.delay(5);
+    const dt = () => Date.now() - start;
+    await time.delay(25);
     assertEquals(Date.now(), start);
     await time.delay(100);
     await time.delay(5);
-    assertEquals(Date.now(), start + 1500);
+    let actualDt = dt();
+    assert(dt() >= 1500, `expected dt ${actualDt} >= 1500`);
+    assert(dt() < 4500, `expected dt ${actualDt} < 4500`);
     await time.delay(200);
     await time.delay(5);
-    assertEquals(Date.now(), start + 4500);
+    actualDt = dt();
+    assert(actualDt >= 4500, `expected dt ${actualDt} >= 4500`);
+    assert(actualDt < 7500, `expected dt ${actualDt} < 7500`);
   } finally {
     time.restore();
   }

--- a/time_test.ts
+++ b/time_test.ts
@@ -548,11 +548,10 @@ Deno.test("FakeTime ticks forward at advanceFrequency when advanceRate is set", 
     assertEquals(Date.now(), start);
     await time.delay(100);
     await time.delay(5);
-    assert(Date.now() >= start + 1500);
-    assert(Date.now() < start + 4500);
+    assertEquals(Date.now(), start + 1500);
     await time.delay(200);
     await time.delay(5);
-    assert(Date.now() >= start + 4500);
+    assertEquals(Date.now(), start + 4500);
   } finally {
     time.restore();
   }

--- a/time_test.ts
+++ b/time_test.ts
@@ -544,7 +544,8 @@ Deno.test("FakeTime ticks forward at advanceFrequency when advanceRate is set", 
 
   try {
     const start = Date.now();
-    await time.delay(50);
+    await time.delay(20);
+    await time.delay(5);
     assertEquals(Date.now(), start);
     await time.delay(100);
     await time.delay(5);

--- a/time_test.ts
+++ b/time_test.ts
@@ -546,12 +546,13 @@ Deno.test("FakeTime ticks forward at advanceFrequency when advanceRate is set", 
     const start = Date.now();
     const dt = () => Date.now() - start;
     await time.delay(25);
-    assertEquals(Date.now(), start);
+    let actualDt = dt();
+    assert(actualDt <= 1500, `expected dt ${actualDt} < 4500`);
     await time.delay(100);
     await time.delay(5);
-    let actualDt = dt();
-    assert(dt() >= 1500, `expected dt ${actualDt} >= 1500`);
-    assert(dt() < 4500, `expected dt ${actualDt} < 4500`);
+    actualDt = dt();
+    assert(actualDt >= 1500, `expected dt ${actualDt} >= 1500`);
+    assert(actualDt < 4500, `expected dt ${actualDt} < 4500`);
     await time.delay(200);
     await time.delay(5);
     actualDt = dt();

--- a/time_test.ts
+++ b/time_test.ts
@@ -535,3 +535,71 @@ Deno.test("runAllAsync runs all microtasks and timers", async () => {
     time.restore();
   }
 });
+
+Deno.test("FakeTime ticks forward when advanceRate is set", async () => {
+  let time: FakeTime = new FakeTime(null, { advanceRate: 1 });
+
+  try {
+    let start: number = Date.now();
+    await time.delay(5);
+    assertEquals(Date.now(), start);
+    await time.delay(5);
+    await time.delay(5);
+    assert(Date.now() >= start + 10);
+    assert(Date.now() < start + 30);
+    await time.delay(15);
+    await time.delay(5);
+    assert(Date.now() >= start + 30);
+    time.restore();
+
+    time = new FakeTime(null, { advanceRate: 1000 });
+    start = Date.now();
+    await time.delay(5);
+    assertEquals(Date.now(), start);
+    await time.delay(5);
+    await time.delay(5);
+    assert(Date.now() >= start + 10000);
+    assert(Date.now() < start + 30000);
+    await time.delay(15);
+    await time.delay(5);
+    assert(Date.now() >= start + 30000);
+  } finally {
+    time.restore();
+  }
+});
+
+Deno.test("FakeTime ticks forward at advanceFrequency when advanceRate is set", async () => {
+  let time: FakeTime = new FakeTime(
+    null,
+    { advanceRate: 1, advanceFrequency: 15 },
+  );
+
+  try {
+    let start: number = Date.now();
+    await time.delay(5);
+    assertEquals(Date.now(), start);
+    await time.delay(10);
+    await time.delay(5);
+    assert(Date.now() >= start + 15);
+    assert(Date.now() < start + 45);
+    await time.delay(25);
+    await time.delay(5);
+    assert(Date.now() >= start + 45);
+    time.restore();
+
+    time = new FakeTime(null, { advanceRate: 1000, advanceFrequency: 15 });
+    start = Date.now();
+    await time.delay(5);
+    assertEquals(Date.now(), start);
+    await time.delay(10);
+    await time.delay(5);
+    assert(Date.now() >= start + 15000);
+    assert(Date.now() < start + 45000);
+    await time.delay(25);
+    await time.delay(5);
+    assert(Date.now() >= start + 45000);
+    start = Date.now();
+  } finally {
+    time.restore();
+  }
+});


### PR DESCRIPTION
For: https://github.com/udibo/mock/issues/7

The problem was that timeout execution is not exact. Depending on the system, the test would fail.

To attempt to resolve the issue, I increased the advanceFrequency for the test with larger delays to ensure that the timeouts are called in the desired order.

The ubuntu ci tests would pass but the macOS ones are still failing. Because of that, I'm closing this PR after creating it. I'm only creating the PR so that I can have a record of changes I attempted to resolve the CI issue.