### PR TITLE
Allow stubbing non function properties and add returnsNext/resolvesNext callbacks

### DIFF
--- a/callbacks.ts
+++ b/callbacks.ts
@@ -26,3 +26,25 @@ export function returnsArgs(
     return Array.prototype.slice.call(arguments, start, end);
   };
 }
+
+export function returnsNext<T>(
+  iterable: Iterable<T>,
+  // deno-lint-ignore no-explicit-any
+): (...args: any[]) => (T | void) {
+  const gen = (function* returnsValue() {
+    yield* iterable;
+  })();
+  return function () {
+    return gen.next().value;
+  };
+}
+
+export function resolvesNext<T>(
+  iterable: AsyncIterable<T>,
+  // deno-lint-ignore no-explicit-any
+): (...args: any[]) => Promise<T | void> {
+  const gen = (async function* returnsValue() {
+    yield* iterable;
+  })();
+  return async () => (await gen.next()).value;
+}

--- a/callbacks_test.ts
+++ b/callbacks_test.ts
@@ -1,5 +1,11 @@
-import { assertEquals } from "./deps.ts";
-import { returnsArg, returnsArgs, returnsThis } from "./callbacks.ts";
+import { assertEquals, delay } from "./deps.ts";
+import {
+  resolvesNext,
+  returnsArg,
+  returnsArgs,
+  returnsNext,
+  returnsThis,
+} from "./callbacks.ts";
 
 Deno.test("returnsThis", () => {
   const callback = returnsThis();
@@ -37,4 +43,50 @@ Deno.test("returnsArgs", () => {
   assertEquals(callback("b", "c"), ["c"]);
   assertEquals(callback("d", "e", "f"), ["e", "f"]);
   assertEquals(callback("d", "e", "f", "g"), ["e", "f"]);
+});
+
+Deno.test("returnsNext array", () => {
+  let results: number[] = [1, 2, 3];
+  let callback = returnsNext(results);
+  assertEquals(callback(), 1);
+  assertEquals(callback(), 2);
+  assertEquals(callback(), 3);
+  assertEquals(callback(), undefined);
+
+  results = [];
+  callback = returnsNext(results);
+  results.push(1, 2, 3);
+  assertEquals(callback(), 1);
+  assertEquals(callback(), 2);
+  assertEquals(callback(), 3);
+  results.push(4);
+  assertEquals(callback(), 4);
+  assertEquals(callback(), undefined);
+  results.push(5);
+  assertEquals(callback(), undefined);
+});
+
+Deno.test("resolvesNext array", async () => {
+  let results: number[] = [1, 2, 3];
+  const asyncIterator = async function* () {
+    await delay(0);
+    yield* results;
+  };
+  let callback = resolvesNext(asyncIterator());
+  assertEquals(await callback(), 1);
+  assertEquals(await callback(), 2);
+  assertEquals(await callback(), 3);
+  assertEquals(await callback(), undefined);
+
+  results = [];
+  callback = resolvesNext(asyncIterator());
+  results.push(1, 2, 3);
+  assertEquals(await callback(), 1);
+  assertEquals(await callback(), 2);
+  assertEquals(await callback(), 3);
+  results.push(4);
+  assertEquals(await callback(), 4);
+  assertEquals(await callback(), undefined);
+  results.push(5);
+  assertEquals(await callback(), undefined);
 });

--- a/deps.ts
+++ b/deps.ts
@@ -1,3 +1,4 @@
+export { delay } from "https://deno.land/std@0.114.0/async/delay.ts";
 export type { DelayOptions } from "https://deno.land/std@0.114.0/async/delay.ts";
 
 export {

--- a/examples/stub_empty_test.ts
+++ b/examples/stub_empty_test.ts
@@ -20,11 +20,6 @@ Deno.test("doAction", () => {
   try {
     assertEquals(doAction(cat, "walk"), undefined);
     assertEquals(doAction(cat, "jump"), undefined);
-
-    action.returns = ["hello", "world"];
-    assertEquals(doAction(cat, "say hello"), "hello");
-    assertEquals(doAction(cat, "say world"), "world");
-    assertEquals(doAction(cat, "say bye"), undefined);
   } finally {
     action.restore();
   }

--- a/examples/stub_function_test.ts
+++ b/examples/stub_function_test.ts
@@ -34,7 +34,7 @@ Deno.test("getUsers", () => {
     assertEquals(getUsers(db, "doe"), ["1 jd", "2 johnd", "3 janedoe"]);
     assertEquals(getUsers(db, "doe", "john"), ["2 johnd"]);
 
-    query.returns.push([[3, "janedoe"]]);
+    returns.push([[3, "janedoe"]]);
     assertEquals(getUsers(db, "doe"), ["3 janedoe"]);
 
     assertEquals(query.calls, [

--- a/examples/stub_returns_next_test.ts
+++ b/examples/stub_returns_next_test.ts
@@ -1,9 +1,9 @@
+import { returnsNext } from "../callbacks.ts";
 import { assertEquals } from "../deps.ts";
 import { Stub, stub } from "../stub.ts";
 
 class Database {
-  // deno-lint-ignore no-explicit-any
-  query(_query: string, _params: any[]): any[][] {
+  query(_query: string, _params: unknown[]): unknown[][] {
     throw new Error("unimplemented");
   }
 }
@@ -24,16 +24,17 @@ function getUsers(
 
 Deno.test("getUsers", () => {
   const db: Database = new Database();
-  const query: Stub<Database> = stub(db, "query", [
+  const returns: [number, string][][] = [
     [[1, "jd"], [2, "johnd"], [3, "janedoe"]],
     [[2, "johnd"]],
-  ]);
+  ];
+  const query: Stub<Database> = stub(db, "query", returnsNext(returns));
 
   try {
     assertEquals(getUsers(db, "doe"), ["1 jd", "2 johnd", "3 janedoe"]);
     assertEquals(getUsers(db, "doe", "john"), ["2 johnd"]);
 
-    query.returns.push([[3, "janedoe"]]);
+    returns.push([[3, "janedoe"]]);
     assertEquals(getUsers(db, "doe"), ["3 janedoe"]);
 
     assertEquals(query.calls, [

--- a/spy_test.ts
+++ b/spy_test.ts
@@ -56,7 +56,7 @@ Deno.test("spy default", () => {
   assertThrows(
     () => func.restore(),
     SpyError,
-    "no instance method to restore",
+    "no instance property to restore",
   );
 });
 
@@ -108,11 +108,11 @@ Deno.test("spy function", () => {
   assertThrows(
     () => func.restore(),
     SpyError,
-    "no instance method to restore",
+    "no instance property to restore",
   );
 });
 
-Deno.test("spy instance method", () => {
+Deno.test("spy instance property", () => {
   const point = new Point(2, 3);
   const func: Spy<Point> = spy(point, "action");
   assertSpyCalls(func, 0);
@@ -201,12 +201,12 @@ Deno.test("spy instance method", () => {
   assertThrows(
     () => func.restore(),
     SpyError,
-    "instance method already restored",
+    "instance property already restored",
   );
   assertThrows(
     () => func(),
     SpyError,
-    "instance method already restored",
+    "instance property already restored",
   );
 });
 
@@ -241,7 +241,7 @@ Deno.test("spy instance method symbol", () => {
   assertThrows(
     () => func.restore(),
     SpyError,
-    "instance method already restored",
+    "instance property already restored",
   );
 });
 
@@ -304,7 +304,7 @@ Deno.test("spy instance method property descriptor", () => {
   assertThrows(
     () => action.restore(),
     SpyError,
-    "instance method already restored",
+    "instance property already restored",
   );
 });
 
@@ -360,7 +360,7 @@ Deno.test("spy instance method property getter/setter", () => {
   assertThrows(
     () => action.restore(),
     SpyError,
-    "instance method already restored",
+    "instance property already restored",
   );
 });
 
@@ -409,6 +409,6 @@ Deno.test("spy instance property getter/setter", () => {
   assertThrows(
     () => x.restore(),
     SpyError,
-    "instance method already restored",
+    "instance property already restored",
   );
 });

--- a/stub.ts
+++ b/stub.ts
@@ -1,51 +1,57 @@
 /** This module is browser compatible. */
 
-import { Spy, spy, SpyCall, SpyError, SpyMixin } from "./spy.ts";
+import { AnySpyInternal, Spy, spy, SpyCall, SpyError } from "./spy.ts";
 
 /** An instance method wrapper that overrides the original method and records all calls made to it. */
 export interface Stub<T> extends Spy<T> {
-  /** A queue of values that the stub will return. */
-  returns: unknown[];
+  /** The original value that was replaced with the stub. */
+  original: unknown;
 }
+export type AnyStub<T> = Stub<T> | Stub<void>;
 
-/** Wraps an instance method with a Stub. */
-function stub<T>(instance: T, method: string | number | symbol): Stub<T>;
+/** Wraps an instance property with a Stub. */
+function stub<T>(instance: T, property: string | number | symbol): Stub<T>;
 function stub<T>(
   instance: T,
-  method: string | number | symbol,
-  returns: unknown[],
-): Stub<T>;
-function stub<T>(
-  instance: T,
-  method: string | number | symbol,
+  property: string | number | symbol,
   // deno-lint-ignore no-explicit-any
   func: (...args: any[]) => unknown,
 ): Stub<T>;
 function stub<T>(
   instance: T,
-  method: string | number | symbol,
+  property: string | number | symbol,
+  value: unknown,
+): Stub<T>;
+function stub<T>(
+  instance: T,
+  property: string | number | symbol,
   // deno-lint-ignore no-explicit-any
-  arrOrFunc?: ((...args: any[]) => unknown) | unknown[],
-): Stub<T> {
-  const stub: Stub<T> = spy(instance, method) as Stub<T>;
-  const stubInternal: SpyMixin<T> = stub as unknown as SpyMixin<T>;
-  stub.returns = Array.isArray(arrOrFunc) ? arrOrFunc : [];
-  // deno-lint-ignore no-explicit-any
-  const func: (...args: any[]) => unknown = typeof arrOrFunc === "function"
-    ? function (this: T) {
-      return arrOrFunc.apply(this, arguments as unknown as unknown[]);
-    }
-    : typeof arrOrFunc === "undefined"
-    ? () => undefined
-    : () => {
-      throw new SpyError("no return for call");
+  valueOrFunc?: ((...args: any[]) => unknown) | unknown,
+): AnyStub<T> {
+  const stub: AnyStub<T> = spy(instance, property) as AnyStub<T>;
+  const stubInternal: AnySpyInternal<T> = stub;
+  const { propertyDescriptor } = stubInternal;
+  if (propertyDescriptor) {
+    Object.defineProperty(stub, "original", propertyDescriptor);
+  }
+  let value: unknown;
+  if (typeof valueOrFunc === "function") {
+    stubInternal.func = function () {
+      return valueOrFunc.apply(this, Array.from(arguments));
     };
-  stubInternal.func = function () {
-    if (stub.returns.length === 0) {
-      return func.apply(this, arguments as unknown as unknown[]);
-    }
-    return stub.returns.shift();
-  };
+    value = stub;
+  } else if (arguments.length < 3) {
+    stubInternal.func = function () {};
+    value = stub;
+  } else {
+    value = valueOrFunc;
+  }
+
+  stubInternal.get = spy(() => value);
+  stubInternal.set = spy((v: unknown) => {
+    value = v;
+  });
+
   return stub;
 }
 

--- a/stub_test.ts
+++ b/stub_test.ts
@@ -1,5 +1,5 @@
 import { assertSpyCall, assertSpyCalls } from "./asserts.ts";
-import { assertEquals, assertNotEquals, assertThrows } from "./deps.ts";
+import { assertEquals, assertThrows } from "./deps.ts";
 import { SpyError, Stub, stub } from "./stub.ts";
 import { Point } from "./test_shared.ts";
 
@@ -7,125 +7,56 @@ Deno.test("stub default", () => {
   const point = new Point(2, 3);
   const func: Stub<Point> = stub(point, "action");
 
-  assertSpyCalls(func, 0);
+  try {
+    assertSpyCalls(func, 0);
 
-  assertEquals(func(), undefined);
-  assertSpyCall(func, 0, {
-    self: undefined,
-    args: [],
-    returned: undefined,
-  });
-  assertSpyCalls(func, 1);
+    assertEquals(func(), undefined);
+    assertSpyCall(func, 0, {
+      self: undefined,
+      args: [],
+      returned: undefined,
+    });
+    assertSpyCalls(func, 1);
 
-  assertEquals(point.action(), undefined);
-  assertSpyCall(func, 1, {
-    self: point,
-    args: [],
-    returned: undefined,
-  });
-  assertSpyCalls(func, 2);
+    assertEquals(point.action(), undefined);
+    assertSpyCall(func, 1, {
+      self: point,
+      args: [],
+      returned: undefined,
+    });
+    assertSpyCalls(func, 2);
 
-  func.returns = [null, 0];
-  assertEquals(func(), null);
-  assertSpyCall(func, 2, {
-    self: undefined,
-    args: [],
-    returned: null,
-  });
-  assertSpyCalls(func, 3);
-
-  assertEquals(point.action(), 0);
-  assertSpyCall(func, 3, {
-    self: point,
-    args: [],
-    returned: 0,
-  });
-  assertSpyCalls(func, 4);
-
-  assertEquals(point.action(), undefined);
-  assertSpyCall(func, 4, {
-    self: point,
-    args: [],
-    returned: undefined,
-  });
-  assertSpyCalls(func, 5);
-
-  func.returns = ["y", "z"];
-  assertEquals(func("x"), "y");
-  assertSpyCall(func, 5, {
-    self: undefined,
-    args: ["x"],
-    returned: "y",
-  });
-  assertSpyCalls(func, 6);
-
-  assertEquals(point.action("x"), "z");
-  assertSpyCall(func, 6, {
-    self: point,
-    args: ["x"],
-    returned: "z",
-  });
-  assertSpyCalls(func, 7);
-
-  assertEquals(point.action("x"), undefined);
-  assertSpyCall(func, 7, {
-    self: point,
-    args: ["x"],
-    returned: undefined,
-  });
-  assertSpyCalls(func, 8);
-
-  assertNotEquals(func, Point.prototype.action);
-  assertEquals(point.action, func);
-
-  func.restore();
+    assertEquals(func.original, Point.prototype.action);
+    assertEquals(point.action, func);
+  } finally {
+    func.restore();
+  }
   assertEquals(point.action, Point.prototype.action);
   assertThrows(
     () => func.restore(),
     SpyError,
-    "instance method already restored",
+    "instance property already restored",
   );
 });
 
-Deno.test("stub returns", () => {
+Deno.test("stub non function property", () => {
   const point = new Point(2, 3);
-  const func: Stub<Point> = stub(point, "action", [5, "x"]);
+  assertEquals(point.x, 2);
+  const prop: Stub<Point> = stub(point, "x", 4);
 
-  assertSpyCalls(func, 0);
+  try {
+    assertSpyCalls(prop, 0);
 
-  assertEquals(func(), 5);
-  assertSpyCall(func, 0, {
-    self: undefined,
-    args: [],
-    returned: 5,
-  });
-  assertSpyCalls(func, 1);
-
-  assertEquals(point.action(), "x");
-  assertSpyCall(func, 1, {
-    self: point,
-    args: [],
-    returned: "x",
-  });
-  assertSpyCalls(func, 2);
-
-  assertThrows(() => func(), SpyError, "no return for call");
-  assertSpyCall(func, 2, {
-    self: undefined,
-    args: [],
-    error: { Class: SpyError, msg: "no return for call" },
-  });
-  assertSpyCalls(func, 3);
-
-  assertNotEquals(func, Point.prototype.action);
-  assertEquals(point.action, func);
-
-  func.restore();
-  assertEquals(point.action, Point.prototype.action);
+    assertThrows(() => prop(), SpyError, "not a function");
+    assertEquals(point.x, 4);
+  } finally {
+    prop.restore();
+  }
+  assertEquals(point.x, 2);
   assertThrows(
-    () => func.restore(),
+    () => prop.restore(),
     SpyError,
-    "instance method already restored",
+    "instance property already restored",
   );
 });
 
@@ -152,57 +83,7 @@ Deno.test("stub function", () => {
   });
   assertSpyCalls(func, 2);
 
-  func.returns = [null, 0];
-  assertEquals(func(), null);
-  assertSpyCall(func, 2, {
-    self: undefined,
-    args: [],
-    returned: null,
-  });
-  assertSpyCalls(func, 3);
-
-  assertEquals(point.action(), 0);
-  assertSpyCall(func, 3, {
-    self: point,
-    args: [],
-    returned: 0,
-  });
-  assertSpyCalls(func, 4);
-
-  assertEquals(point.action(), 2);
-  assertSpyCall(func, 4, {
-    self: point,
-    args: [],
-    returned: 2,
-  });
-  assertSpyCalls(func, 5);
-
-  func.returns = ["y", "z"];
-  assertEquals(func("x"), "y");
-  assertSpyCall(func, 5, {
-    self: undefined,
-    args: ["x"],
-    returned: "y",
-  });
-  assertSpyCalls(func, 6);
-
-  assertEquals(point.action("x"), "z");
-  assertSpyCall(func, 6, {
-    self: point,
-    args: ["x"],
-    returned: "z",
-  });
-  assertSpyCalls(func, 7);
-
-  assertEquals(point.action("y"), "d");
-  assertSpyCall(func, 7, {
-    self: point,
-    args: ["y"],
-    returned: "d",
-  });
-  assertSpyCalls(func, 8);
-
-  assertNotEquals(func, Point.prototype.action);
+  assertEquals(func.original, Point.prototype.action);
   assertEquals(point.action, func);
 
   func.restore();
@@ -210,6 +91,6 @@ Deno.test("stub function", () => {
   assertThrows(
     () => func.restore(),
     SpyError,
-    "instance method already restored",
+    "instance property already restored",
   );
 });


### PR DESCRIPTION
Closes https://github.com/udibo/mock/issues/11

Previously stub had the option to pass an array of values to return for each call. I've removed that call signature and added new callback helper functions for being able to do that. If you were using that feature like in the following example.

```ts
const func = stub(obj, "action", [1, 2, 3])
assertEquals(obj.action(), 1);
assertEquals(obj.action(), 2);
assertEquals(obj.action(), 3);
```

You will need to wrap the array with a returnsNext call to get the same behavior.

```ts
const func = stub(obj, "action", returnsNext([1, 2, 3]))
assertEquals(obj.action(), 1);
assertEquals(obj.action(), 2);
assertEquals(obj.action(), 3);
```

Now if the third argument is set and it is not a function, the stubbed property will be set to that value until the stub is restored. Any changes to the property while stubbed will not affect the object once it is restored. When you restore the property, it will revert back to what it originally was at the time that you replaced it with a stub.