### PR TITLE
feat(spy): Adds argument support for function calls

### DIFF
--- a/spy.ts
+++ b/spy.ts
@@ -60,9 +60,15 @@ export class SpyMixin<T> {
 }
 
 /** A function or instance method wrapper that records all calls made to it. */
-export interface Spy<T> {
+
+export interface Spy<
+  T,
   // deno-lint-ignore no-explicit-any
-  (this: T | void, ...args: any[]): any;
+  TArgs extends any[] = any[],
+  // deno-lint-ignore no-explicit-any
+  TReturn extends any = any,
+> {
+  (this: T | void, ...args: TArgs): TReturn;
   /**
    * Information about calls made to the function or instance method or getter/setter being spied on.
    */
@@ -79,8 +85,9 @@ export interface Spy<T> {
 export type AnySpy<T> = Spy<T> | Spy<void>;
 export type AnySpyInternal<T> = SpyMixin<T> | SpyMixin<void>;
 function spy(): Spy<void>;
-// deno-lint-ignore no-explicit-any
-function spy(func: (...args: any[]) => unknown): Spy<void>;
+function spy<TArgs extends unknown[], TReturn extends unknown>(
+  func: (...args: TArgs) => TReturn,
+): Spy<void, TArgs, TReturn>;
 function spy<T>(obj: T, property: string | number | symbol): Spy<T>;
 function spy<T>(
   // deno-lint-ignore no-explicit-any

--- a/spy_test.ts
+++ b/spy_test.ts
@@ -96,6 +96,22 @@ Deno.test("spy function", () => {
   });
   assertSpyCalls(func, 4);
 
+  // Assert functions with variable types
+  const spiedFn = spy((a: number, b: boolean) => b ? a - 1 : a);
+  assertEquals(spiedFn(1, true), 0);
+  assertSpyCall(spiedFn, 0, {
+    returned: 0,
+    args: [1, true],
+  });
+
+  assertEquals(spiedFn(1, false), 1);
+  assertSpyCall(spiedFn, 1, {
+    returned: 1,
+    args: [1, false],
+  });
+
+  assertSpyCalls(spiedFn, 2);
+
   const point: Point = new Point(2, 3);
   assertEquals(func(Point, stringifyPoint, point), Point);
   assertSpyCall(func, 4, {


### PR DESCRIPTION
## Description

I was recently using this library in a small Deno project and found that the typing on function calls was a bit lacking and was causing some TS errors since I would pass a function that required multiple arguments, but the returned type only ever had 1 listed. 

## Contents

I've upgraded the overload responsible for function call spying to include some defaults to the values, as well as to more strongly type the returned function. Similarly, I've added a test to specifically check that returned noted function signature carries over to the spied counterpart, e.g. a function of type `(a: number: b: string) => number` should have an equivalent signature when run through the `spy()` function.

## Test Results

Full test results can be included if needed, but I believe the summary should hopefully be enough.

```
test result: ok. 67 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out (1s)
```
