### PR TITLE
Replace unknown defaults with any defaults and make self assertions use assertEquals

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Mock
 
-[![release](https://img.shields.io/badge/release-0.14.0-success)](https://github.com/udibo/mock/releases/tag/0.14.0)
-[![deno doc](https://doc.deno.land/badge.svg)](https://doc.deno.land/https/deno.land/x/mock@0.14.0/mod.ts)
+[![release](https://img.shields.io/badge/release-0.15.0-success)](https://github.com/udibo/mock/releases/tag/0.15.0)
+[![deno doc](https://doc.deno.land/badge.svg)](https://doc.deno.land/https/deno.land/x/mock@0.15.0/mod.ts)
 [![CI](https://github.com/udibo/mock/workflows/CI/badge.svg)](https://github.com/udibo/mock/actions?query=workflow%3ACI)
 [![codecov](https://codecov.io/gh/udibo/mock/branch/main/graph/badge.svg?token=TXORMSEHM7)](https://codecov.io/gh/udibo/mock)
 [![license](https://img.shields.io/github/license/udibo/mock)](https://github.com/udibo/mock/blob/master/LICENSE)
@@ -30,9 +30,9 @@ imported directly from GitHub using raw content URLs.
 
 ```ts
 // Import from Deno's third party module registry
-import { spy, stub } from "https://deno.land/x/mock@0.14.0/mod.ts";
+import { spy, stub } from "https://deno.land/x/mock@0.15.0/mod.ts";
 // Import from GitHub
-import { spy, stub } "https://raw.githubusercontent.com/udibo/mock/0.14.0/mod.ts";
+import { spy, stub } "https://raw.githubusercontent.com/udibo/mock/0.15.0/mod.ts";
 ```
 
 If you do not need all of the sub-modules, you can choose to just import the
@@ -40,12 +40,12 @@ sub-modules you need.
 
 ```ts
 // Import from Deno's third party module registry
-import { spy, stub } from "https://deno.land/x/mock@0.14.0/mock.ts";
+import { spy, stub } from "https://deno.land/x/mock@0.15.0/mock.ts";
 // Import from GitHub
 import {
   spy,
   stub,
-} from "https://raw.githubusercontent.com/udibo/mock/0.14.0/mock.ts";
+} from "https://raw.githubusercontent.com/udibo/mock/0.15.0/mock.ts";
 ```
 
 #### Sub-modules
@@ -69,7 +69,7 @@ If a Node.js package has the type "module" specified in its package.json file,
 the JavaScript bundle can be imported as a `.js` file.
 
 ```js
-import { spy, stub } from "./mock_0.14.0.js";
+import { spy, stub } from "./mock_0.15.0.js";
 ```
 
 The default type for Node.js packages is "commonjs". To import the bundle into a
@@ -77,7 +77,7 @@ commonjs package, the file extension of the JavaScript bundle must be changed
 from `.js` to `.mjs`.
 
 ```js
-import { spy, stub } from "./mock_0.14.0.mjs";
+import { spy, stub } from "./mock_0.15.0.mjs";
 ```
 
 See [Node.js Documentation](https://nodejs.org/api/esm.html) for more
@@ -96,7 +96,7 @@ modules must have the type attribute set to "module".
 
 ```js
 // main.js
-import { spy, stub } from "./mock_0.14.0.js";
+import { spy, stub } from "./mock_0.15.0.js";
 ```
 
 You can also embed a module script directly into an HTML file by placing the
@@ -104,7 +104,7 @@ JavaScript code within the body of the script tag.
 
 ```html
 <script type="module">
-  import { spy, stub } from "./mock_0.14.0.js";
+  import { spy, stub } from "./mock_0.15.0.js";
 </script>
 ```
 
@@ -120,7 +120,7 @@ a try block then restore the function in a finally block to ensure the original
 instance method is restored before continuing to other tests. The same applies
 when using fake time.
 
-See [deno docs](https://doc.deno.land/https/deno.land/x/mock@0.14.0/mod.ts) for
+See [deno docs](https://doc.deno.land/https/deno.land/x/mock@0.15.0/mod.ts) for
 more information.
 
 ### Spy
@@ -136,7 +136,7 @@ for any calls made to it.
 
 ```ts
 import { assertEquals } from "https://deno.land/std@0.130.0/testing/asserts.ts";
-import { assertSpyCall, spy } from "https://deno.land/x/mock@0.14.0/mod.ts";
+import { assertSpyCall, spy } from "https://deno.land/x/mock@0.15.0/mod.ts";
 
 function add(
   a: number,
@@ -167,7 +167,7 @@ import {
   assertSpyCall,
   assertSpyCalls,
   spy,
-} from "https://deno.land/x/mock@0.14.0/mod.ts";
+} from "https://deno.land/x/mock@0.15.0/mod.ts";
 
 function filter<T>(values: T[], callback: (value: T) => boolean): any[] {
   return values.filter(callback);
@@ -202,7 +202,7 @@ import {
   assertSpyCall,
   assertSpyCalls,
   spy,
-} from "https://deno.land/x/mock@0.14.0/mod.ts";
+} from "https://deno.land/x/mock@0.15.0/mod.ts";
 
 class Database {
   // deno-lint-ignore no-explicit-any
@@ -293,7 +293,7 @@ import {
   assertSpyCall,
   assertSpyCalls,
   stub,
-} from "https://deno.land/x/mock@0.14.0/mod.ts";
+} from "https://deno.land/x/mock@0.15.0/mod.ts";
 
 class Cat {
   action(name: string): any {
@@ -345,7 +345,7 @@ import {
   assertSpyCalls,
   resolvesNext,
   stub,
-} from "https://deno.land/x/mock@0.14.0/mod.ts";
+} from "https://deno.land/x/mock@0.15.0/mod.ts";
 
 class Database {
   query(_query: string, _params: unknown[]): Promise<unknown[][]> {
@@ -427,7 +427,7 @@ import {
   FakeTime,
   Spy,
   spy,
-} from "https://deno.land/x/mock@0.14.0/mod.ts";
+} from "https://deno.land/x/mock@0.15.0/mod.ts";
 
 function secondInterval(cb: () => void): void {
   setInterval(cb, 1000);

--- a/asserts.ts
+++ b/asserts.ts
@@ -5,7 +5,6 @@ import {
   AssertionError,
   assertIsError,
   assertRejects,
-  assertStrictEquals,
 } from "./deps.ts";
 import { Spy, SpyCall } from "./mock.ts";
 
@@ -89,7 +88,7 @@ export function assertSpyCall<
 
     if ("self" in expected) {
       try {
-        assertStrictEquals(call.self, expected.self);
+        assertEquals(call.self, expected.self);
       } catch (e) {
         let message = expected.self
           ? "spy not called as method on expected self:\n"

--- a/asserts.ts
+++ b/asserts.ts
@@ -33,9 +33,12 @@ export function assertSpyCalls<
 
 /** Call information recorded by a spy. */
 export interface ExpectedSpyCall<
-  Self = unknown,
-  Args extends unknown[] = unknown[],
-  Return = unknown,
+  // deno-lint-ignore no-explicit-any
+  Self = any,
+  // deno-lint-ignore no-explicit-any
+  Args extends unknown[] = any[],
+  // deno-lint-ignore no-explicit-any
+  Return = any,
 > {
   /** Arguments passed to a function when called. */
   args?: [...Args, ...unknown[]];

--- a/asserts_test.ts
+++ b/asserts_test.ts
@@ -213,7 +213,7 @@ Deno.test("assertSpyCall method", () => {
   assertThrows(
     () =>
       assertSpyCall(spyMethod, 1, {
-        self: new Point(2, 3),
+        self: new Point(1, 2),
       }),
     AssertionError,
     "spy not called as method on expected self",
@@ -591,7 +591,7 @@ Deno.test("assertSpyCallAsync method", async () => {
   await assertRejects(
     () =>
       assertSpyCallAsync(spyMethod, 1, {
-        self: new Point(2, 3),
+        self: new Point(1, 2),
       }),
     AssertionError,
     "spy not called as method on expected self",

--- a/callbacks.ts
+++ b/callbacks.ts
@@ -4,8 +4,10 @@ import { MockError } from "./mock.ts";
 
 /** Creates a function that returns the instance the method was called on. */
 export function returnsThis<
-  Self = unknown,
-  Args extends unknown[] = unknown[],
+  // deno-lint-ignore no-explicit-any
+  Self = any,
+  // deno-lint-ignore no-explicit-any
+  Args extends unknown[] = any[],
 >(): (this: Self, ...args: Args) => Self {
   return function (this: Self): Self {
     return this;
@@ -13,7 +15,8 @@ export function returnsThis<
 }
 
 /** Creates a function that returns one of its arguments. */
-export function returnsArg<Arg, Self = unknown>(
+// deno-lint-ignore no-explicit-any
+export function returnsArg<Arg, Self = any>(
   idx: number,
 ): (this: Self, ...args: Arg[]) => Arg {
   return function (...args: Arg[]): Arg {
@@ -24,7 +27,8 @@ export function returnsArg<Arg, Self = unknown>(
 /** Creates a function that returns its arguments or a subset of them. If end is specified, it will return arguments up to but not including the end. */
 export function returnsArgs<
   Args extends unknown[],
-  Self = unknown,
+  // deno-lint-ignore no-explicit-any
+  Self = any,
 >(
   start = 0,
   end?: number,
@@ -37,8 +41,10 @@ export function returnsArgs<
 /** Creates a function that returns the iterable values. Any iterable values that are errors will be thrown. */
 export function returnsNext<
   Return,
-  Self = unknown,
-  Args extends unknown[] = unknown[],
+  // deno-lint-ignore no-explicit-any
+  Self = any,
+  // deno-lint-ignore no-explicit-any
+  Args extends unknown[] = any[],
 >(
   values: Iterable<Return | Error>,
 ): (this: Self, ...args: Args) => Return {
@@ -61,8 +67,10 @@ export function returnsNext<
 /** Creates a function that resolves the awaited iterable values. Any awaited iterable values that are errors will be thrown. */
 export function resolvesNext<
   Return,
-  Self = unknown,
-  Args extends unknown[] = unknown[],
+  // deno-lint-ignore no-explicit-any
+  Self = any,
+  // deno-lint-ignore no-explicit-any
+  Args extends unknown[] = any[],
 >(
   iterable:
     | Iterable<Return | Error | Promise<Return | Error>>

--- a/mock.ts
+++ b/mock.ts
@@ -10,9 +10,12 @@ export class MockError extends Error {
 
 /** Call information recorded by a spy. */
 export interface SpyCall<
-  Self = unknown,
-  Args extends unknown[] = unknown[],
-  Return = unknown,
+  // deno-lint-ignore no-explicit-any
+  Self = any,
+  // deno-lint-ignore no-explicit-any
+  Args extends unknown[] = any[],
+  // deno-lint-ignore no-explicit-any
+  Return = any,
 > {
   /** Arguments passed to a function when called. */
   args: Args;
@@ -26,9 +29,12 @@ export interface SpyCall<
 
 /** A function or instance method wrapper that records all calls made to it. */
 export interface Spy<
-  Self,
-  Args extends unknown[],
-  Return,
+  // deno-lint-ignore no-explicit-any
+  Self = any,
+  // deno-lint-ignore no-explicit-any
+  Args extends unknown[] = any[],
+  // deno-lint-ignore no-explicit-any
+  Return = any,
 > {
   (this: Self, ...args: Args): Return;
   /** The function that is being spied on. */
@@ -43,8 +49,10 @@ export interface Spy<
 
 /** Wraps a function with a Spy. */
 function functionSpy<
-  Self = unknown,
-  Args extends unknown[] = unknown[],
+  // deno-lint-ignore no-explicit-any
+  Self = any,
+  // deno-lint-ignore no-explicit-any
+  Args extends unknown[] = any[],
   Return = undefined,
 >(): Spy<Self, Args, Return>;
 function functionSpy<
@@ -275,9 +283,11 @@ function methodSpy<
 
 /** Wraps a function or instance method with a Spy. */
 export function spy<
-  Self = unknown,
-  Args extends unknown[] = unknown[],
-  Return = unknown,
+  // deno-lint-ignore no-explicit-any
+  Self = any,
+  // deno-lint-ignore no-explicit-any
+  Args extends unknown[] = any[],
+  Return = undefined,
 >(): Spy<Self, Args, Return>;
 export function spy<
   Self,
@@ -309,9 +319,12 @@ export function spy<
 
 /** An instance method replacement that records all calls made to it. */
 export interface Stub<
-  Self,
-  Args extends unknown[],
-  Return,
+  // deno-lint-ignore no-explicit-any
+  Self = any,
+  // deno-lint-ignore no-explicit-any
+  Args extends unknown[] = any[],
+  // deno-lint-ignore no-explicit-any
+  Return = any,
 > extends Spy<Self, Args, Return> {
   /** The function that is used instead of the original. */
   fake: (this: Self, ...args: Args) => Return;
@@ -320,7 +333,8 @@ export interface Stub<
 /** Replaces an instance method with a Stub. */
 export function stub<
   Self,
-  Args extends unknown[] = unknown[],
+  // deno-lint-ignore no-explicit-any
+  Args extends unknown[] = any[],
   Return = undefined,
 >(self: Self, property: keyof Self): Stub<Self, Args, Return>;
 export function stub<

--- a/mock.ts
+++ b/mock.ts
@@ -367,8 +367,7 @@ export function stub<
     throw new MockError("cannot spy on non configurable instance method");
   }
 
-  const fake = func ??
-    (function () {}) as (this: Self, ...args: Args) => Return;
+  const fake = func ?? (() => {}) as (this: Self, ...args: Args) => Return;
 
   const original = self[property] as unknown as (
       this: Self,

--- a/mock.ts
+++ b/mock.ts
@@ -367,7 +367,8 @@ export function stub<
     throw new MockError("cannot spy on non configurable instance method");
   }
 
-  const fake = func ?? (() => {}) as (this: Self, ...args: Args) => Return;
+  const fake = func ??
+    (function () {}) as (this: Self, ...args: Args) => Return;
 
   const original = self[property] as unknown as (
       this: Self,

--- a/time_test.ts
+++ b/time_test.ts
@@ -7,7 +7,7 @@ import {
 } from "./deps.ts";
 import { FakeDate, FakeTime, NativeDate } from "./time.ts";
 import { MockError, spy, SpyCall, stub } from "./mock.ts";
-import { assertSpyCall, assertSpyCalls } from "./asserts.ts";
+import { assertSpyCall } from "./asserts.ts";
 
 function fromNow(): () => number {
   const start: number = Date.now();
@@ -87,7 +87,6 @@ Deno.test("FakeDate instance methods passthrough to Date instance methods", () =
         args,
         returned,
       });
-      assertSpyCalls(func, 1);
     }
   });
   Object.getOwnPropertySymbols(Date.prototype).forEach((method: symbol) => {
@@ -104,7 +103,6 @@ Deno.test("FakeDate instance methods passthrough to Date instance methods", () =
         args,
         returned,
       });
-      assertSpyCalls(func, 1);
     }
   });
 });


### PR DESCRIPTION
As part of the refactor for [0.14.0](https://github.com/udibo/mock/releases/tag/0.14.0) from https://github.com/udibo/mock/pull/33, I changed self to using assertStrictEquals instead of assertEquals. I've decided against that change because it makes it harder to make assertions about self when you don't have access to the object.