### PR TITLE
Deprecate in favor of std/testing/mock.ts and std/testing/time.ts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Mock
 
-[![release](https://img.shields.io/badge/release-0.15.0-success)](https://github.com/udibo/mock/releases/tag/0.15.0)
-[![deno doc](https://doc.deno.land/badge.svg)](https://doc.deno.land/https/deno.land/x/mock@0.15.0/mod.ts)
+[![release](https://img.shields.io/badge/release-0.15.1-success)](https://github.com/udibo/mock/releases/tag/0.15.1)
+[![deno doc](https://doc.deno.land/badge.svg)](https://doc.deno.land/https/deno.land/x/mock@0.15.1/mod.ts)
 [![CI](https://github.com/udibo/mock/workflows/CI/badge.svg)](https://github.com/udibo/mock/actions?query=workflow%3ACI)
 [![codecov](https://codecov.io/gh/udibo/mock/branch/main/graph/badge.svg?token=TXORMSEHM7)](https://codecov.io/gh/udibo/mock)
 [![license](https://img.shields.io/github/license/udibo/mock)](https://github.com/udibo/mock/blob/master/LICENSE)
@@ -30,9 +30,9 @@ imported directly from GitHub using raw content URLs.
 
 ```ts
 // Import from Deno's third party module registry
-import { spy, stub } from "https://deno.land/x/mock@0.15.0/mod.ts";
+import { spy, stub } from "https://deno.land/x/mock@0.15.1/mod.ts";
 // Import from GitHub
-import { spy, stub } "https://raw.githubusercontent.com/udibo/mock/0.15.0/mod.ts";
+import { spy, stub } "https://raw.githubusercontent.com/udibo/mock/0.15.1/mod.ts";
 ```
 
 If you do not need all of the sub-modules, you can choose to just import the
@@ -40,12 +40,12 @@ sub-modules you need.
 
 ```ts
 // Import from Deno's third party module registry
-import { spy, stub } from "https://deno.land/x/mock@0.15.0/mock.ts";
+import { spy, stub } from "https://deno.land/x/mock@0.15.1/mock.ts";
 // Import from GitHub
 import {
   spy,
   stub,
-} from "https://raw.githubusercontent.com/udibo/mock/0.15.0/mock.ts";
+} from "https://raw.githubusercontent.com/udibo/mock/0.15.1/mock.ts";
 ```
 
 #### Sub-modules
@@ -69,7 +69,7 @@ If a Node.js package has the type "module" specified in its package.json file,
 the JavaScript bundle can be imported as a `.js` file.
 
 ```js
-import { spy, stub } from "./mock_0.15.0.js";
+import { spy, stub } from "./mock_0.15.1.js";
 ```
 
 The default type for Node.js packages is "commonjs". To import the bundle into a
@@ -77,7 +77,7 @@ commonjs package, the file extension of the JavaScript bundle must be changed
 from `.js` to `.mjs`.
 
 ```js
-import { spy, stub } from "./mock_0.15.0.mjs";
+import { spy, stub } from "./mock_0.15.1.mjs";
 ```
 
 See [Node.js Documentation](https://nodejs.org/api/esm.html) for more
@@ -96,7 +96,7 @@ modules must have the type attribute set to "module".
 
 ```js
 // main.js
-import { spy, stub } from "./mock_0.15.0.js";
+import { spy, stub } from "./mock_0.15.1.js";
 ```
 
 You can also embed a module script directly into an HTML file by placing the
@@ -104,7 +104,7 @@ JavaScript code within the body of the script tag.
 
 ```html
 <script type="module">
-  import { spy, stub } from "./mock_0.15.0.js";
+  import { spy, stub } from "./mock_0.15.1.js";
 </script>
 ```
 
@@ -120,7 +120,7 @@ a try block then restore the function in a finally block to ensure the original
 instance method is restored before continuing to other tests. The same applies
 when using fake time.
 
-See [deno docs](https://doc.deno.land/https/deno.land/x/mock@0.15.0/mod.ts) for
+See [deno docs](https://doc.deno.land/https/deno.land/x/mock@0.15.1/mod.ts) for
 more information.
 
 ### Spy
@@ -135,8 +135,8 @@ anything, you can create an empty spy. An empty spy will just return undefined
 for any calls made to it.
 
 ```ts
-import { assertEquals } from "https://deno.land/std@0.130.0/testing/asserts.ts";
-import { assertSpyCall, spy } from "https://deno.land/x/mock@0.15.0/mod.ts";
+import { assertEquals } from "https://deno.land/std@0.135.0/testing/asserts.ts";
+import { assertSpyCall, spy } from "https://deno.land/x/mock@0.15.1/mod.ts";
 
 function add(
   a: number,
@@ -162,12 +162,12 @@ If you have a function that takes a callback that needs to still behave
 normally, you can wrap it with a spy.
 
 ```ts
-import { assertEquals } from "https://deno.land/std@0.130.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.135.0/testing/asserts.ts";
 import {
   assertSpyCall,
   assertSpyCalls,
   spy,
-} from "https://deno.land/x/mock@0.15.0/mod.ts";
+} from "https://deno.land/x/mock@0.15.1/mod.ts";
 
 function filter<T>(values: T[], callback: (value: T) => boolean): any[] {
   return values.filter(callback);
@@ -197,12 +197,12 @@ method. If it is not restored and you attempt to wrap it again, it will throw a
 spy error saying "already spying on function".
 
 ```ts
-import { assertEquals } from "https://deno.land/std@0.130.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.135.0/testing/asserts.ts";
 import {
   assertSpyCall,
   assertSpyCalls,
   spy,
-} from "https://deno.land/x/mock@0.15.0/mod.ts";
+} from "https://deno.land/x/mock@0.15.1/mod.ts";
 
 class Database {
   // deno-lint-ignore no-explicit-any
@@ -288,12 +288,12 @@ you can create an empty stub. An empty stub will just return undefined for any
 calls made to it.
 
 ```ts
-import { assertEquals } from "https://deno.land/std@0.130.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.135.0/testing/asserts.ts";
 import {
   assertSpyCall,
   assertSpyCalls,
   stub,
-} from "https://deno.land/x/mock@0.15.0/mod.ts";
+} from "https://deno.land/x/mock@0.15.1/mod.ts";
 
 class Cat {
   action(name: string): any {
@@ -339,13 +339,13 @@ considered complete if called after all values have been returned. The callback
 will return undefined to each call after the iterator is done.
 
 ```ts
-import { assertEquals } from "https://deno.land/std@0.130.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.135.0/testing/asserts.ts";
 import {
   assertSpyCallAsync,
   assertSpyCalls,
   resolvesNext,
   stub,
-} from "https://deno.land/x/mock@0.15.0/mod.ts";
+} from "https://deno.land/x/mock@0.15.1/mod.ts";
 
 class Database {
   query(_query: string, _params: unknown[]): Promise<unknown[][]> {
@@ -427,7 +427,7 @@ import {
   FakeTime,
   Spy,
   spy,
-} from "https://deno.land/x/mock@0.15.0/mod.ts";
+} from "https://deno.land/x/mock@0.15.1/mod.ts";
 
 function secondInterval(cb: () => void): void {
   setInterval(cb, 1000);

--- a/mock.ts
+++ b/mock.ts
@@ -281,7 +281,11 @@ function methodSpy<
   return spy;
 }
 
-/** Wraps a function or instance method with a Spy. */
+/**
+ * Wraps a function or instance method with a Spy.
+ *
+ * @deprecated Use https://deno.land/std/testing/mock.ts instead.
+ */
 export function spy<
   // deno-lint-ignore no-explicit-any
   Self = any,
@@ -330,7 +334,11 @@ export interface Stub<
   fake: (this: Self, ...args: Args) => Return;
 }
 
-/** Replaces an instance method with a Stub. */
+/**
+ * Replaces an instance method with a Stub.
+ *
+ * @deprecated Use https://deno.land/std/testing/mock.ts instead.
+ */
 export function stub<
   Self,
   // deno-lint-ignore no-explicit-any

--- a/test_deps.ts
+++ b/test_deps.ts
@@ -1,1 +1,1 @@
-export { delay } from "https://deno.land/std@0.130.0/async/delay.ts";
+export { delay } from "https://deno.land/std@0.135.0/async/delay.ts";

--- a/time.ts
+++ b/time.ts
@@ -172,6 +172,8 @@ let time: FakeTime | undefined = undefined;
 /**
  * Overrides the real Date object and timer functions with fake ones that can be
  * controlled through the fake time instance.
+ *
+ * @deprecated Use https://deno.land/std/testing/time.ts instead.
  */
 export class FakeTime {
   private _now: number;

--- a/time_deps.ts
+++ b/time_deps.ts
@@ -1,7 +1,9 @@
-export type { DelayOptions } from "https://deno.land/std@0.130.0/async/delay.ts";
+export type { DelayOptions } from "https://deno.land/std@0.135.0/async/delay.ts";
 
-export { RBTree } from "https://deno.land/x/collections@0.12.0/trees/rb_tree.ts";
-export { ascend } from "https://deno.land/x/collections@0.12.0/comparators.ts";
+export {
+  ascend,
+  RBTree,
+} from "https://deno.land/std@0.135.0/collections/rb_tree.ts";
 
 export {
   applyInstanceMixins,


### PR DESCRIPTION
This module has been added to std/testing as https://deno.land/std/testing/mock.ts and https://deno.land/std/testing/time.ts